### PR TITLE
feat: add legal pages, rate limiting, and forgot password flow

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  let body: { email?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { email } = body;
+  if (!email || typeof email !== 'string') {
+    return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${request.nextUrl.origin}/auth/reset-password`,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Always return success to prevent user enumeration
+  return NextResponse.json({ success: true });
+}

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Suspense } from 'react';
+import { ForgotPassword } from '@/views/ForgotPassword';
+
+export const dynamic = 'force-dynamic';
+
+export default function ForgotPasswordPageWrapper() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ForgotPassword />
+    </Suspense>
+  );
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Suspense } from 'react';
+import { ResetPassword } from '@/views/ResetPassword';
+
+export const dynamic = 'force-dynamic';
+
+export default function ResetPasswordPageWrapper() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ResetPassword />
+    </Suspense>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -216,8 +216,8 @@ export default function PrivacyPage() {
             </ul>
             <p className="text-base leading-relaxed">
               To exercise any of these rights, please contact us at{" "}
-              <a href="mailto:hello@mythirdplace.in" className="font-bold underline hover:text-primary">
-                hello@mythirdplace.in
+              <a href="mailto:hello@rapchai.com" className="font-bold underline hover:text-primary">
+                hello@rapchai.com
               </a>
               . We will respond within 30 days.
             </p>
@@ -252,10 +252,10 @@ export default function PrivacyPage() {
               If you have questions or concerns about this Privacy Policy or how we handle your data, please
               contact us at{" "}
               <a
-                href="mailto:hello@mythirdplace.in"
+                href="mailto:hello@rapchai.com"
                 className="font-bold underline hover:text-primary"
               >
-                hello@mythirdplace.in
+                hello@rapchai.com
               </a>
             </p>
           </section>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,276 @@
+import Link from "next/link";
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        {/* Back nav */}
+        <nav className="mb-8">
+          <Link
+            href="/"
+            className="inline-block border-2 border-foreground bg-background px-4 py-2 text-sm font-bold uppercase tracking-wider shadow-brutal hover:shadow-brutal-none hover:translate-x-[4px] hover:translate-y-[4px] transition-all duration-150"
+          >
+            ← Back to Home
+          </Link>
+        </nav>
+
+        {/* Header */}
+        <div className="border-2 border-foreground bg-primary p-6 shadow-brutal-lg mb-8">
+          <h1 className="text-4xl font-extrabold uppercase tracking-wider text-primary-foreground">
+            Privacy Policy
+          </h1>
+          <p className="text-primary-foreground/80 mt-2 font-medium">
+            Effective Date: April 1, 2026
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {/* Introduction */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <p className="text-base leading-relaxed">
+              My Third Place (&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;) is committed to protecting your privacy. This Privacy Policy
+              explains how we collect, use, and safeguard your information when you use our community platform.
+              By using My Third Place, you agree to the practices described in this policy.
+            </p>
+          </section>
+
+          {/* 1. Information We Collect */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">1. Information We Collect</h2>
+            <p className="text-base font-bold mb-2">Information you provide directly:</p>
+            <ul className="space-y-2 text-base mb-4">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Email address and display name (when you create an account)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Profile information you choose to add
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Content you post in discussions or event listings
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Event registration details (name, contact info for RSVP)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Referral codes you enter or share
+              </li>
+            </ul>
+            <p className="text-base font-bold mb-2">Information collected automatically:</p>
+            <ul className="space-y-2 text-base mb-4">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Device and browser type, operating system
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Pages visited, features used, and time spent on the platform
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                IP address and approximate location (city-level)
+              </li>
+            </ul>
+            <p className="text-base font-bold mb-2">Information from third-party sign-in (Google OAuth):</p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-secondary border border-foreground flex-shrink-0" />
+                Name, email address, and profile picture from your Google account
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-secondary border border-foreground flex-shrink-0" />
+                We do not receive your Google password
+              </li>
+            </ul>
+          </section>
+
+          {/* 2. How We Use Your Information */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">2. How We Use Your Information</h2>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To create and manage your account
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To provide access to communities, events, and discussions
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To send event confirmation emails and platform notifications (if opted in)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To personalise your experience (recommended events, communities)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To track platform usage for product improvements via Google Analytics (GTM)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To process referrals and apply associated benefits
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                To detect and prevent fraud, abuse, and security incidents
+              </li>
+            </ul>
+          </section>
+
+          {/* 3. Sharing */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">3. Information Sharing</h2>
+            <p className="text-base leading-relaxed mb-3">
+              We do not sell your personal information. We share your data only in the following limited circumstances:
+            </p>
+            <ul className="space-y-2 text-base mb-3">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                <span><strong>Supabase</strong> — our database and authentication provider, which stores your account data securely</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                <span><strong>Google (GTM/Analytics)</strong> — anonymised usage analytics to understand platform behaviour</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                <span><strong>Payment processors</strong> — only when you make a payment for a paid event (we do not store card details)</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                <span><strong>Event organisers</strong> — your registration information is shared with the organiser of events you register for</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                <span><strong>Legal requirements</strong> — if required by law or to protect our legal rights</span>
+              </li>
+            </ul>
+          </section>
+
+          {/* 4. Cookies */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">4. Cookies & Tracking</h2>
+            <p className="text-base leading-relaxed mb-3">
+              We use the following types of cookies and tracking technologies:
+            </p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                <span><strong>Authentication cookies</strong> — essential for keeping you signed in (provided by Supabase)</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                <span><strong>Preference cookies</strong> — store your theme preference (light/dark mode)</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                <span><strong>Analytics (Google Tag Manager)</strong> — collects anonymised data about how you use the platform to help us improve it</span>
+              </li>
+            </ul>
+          </section>
+
+          {/* 5. Data Retention */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">5. Data Retention</h2>
+            <p className="text-base leading-relaxed">
+              We retain your account information for as long as your account is active or as needed to provide our
+              services. If you delete your account, we will delete or anonymise your personal information within 30
+              days, except where we are required to retain it for legal, fraud-prevention, or accounting purposes.
+              Content you have posted (discussions, event listings) may persist in anonymised form.
+            </p>
+          </section>
+
+          {/* 6. Your Rights */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">6. Your Rights</h2>
+            <p className="text-base leading-relaxed mb-3">
+              You have the right to:
+            </p>
+            <ul className="space-y-2 text-base mb-3">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Access the personal information we hold about you
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Correct inaccurate or incomplete information
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Request deletion of your account and personal data
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Opt out of non-essential communications
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Object to processing of your data for analytics purposes
+              </li>
+            </ul>
+            <p className="text-base leading-relaxed">
+              To exercise any of these rights, please contact us at{" "}
+              <a href="mailto:hello@mythirdplace.in" className="font-bold underline hover:text-primary">
+                hello@mythirdplace.in
+              </a>
+              . We will respond within 30 days.
+            </p>
+          </section>
+
+          {/* 7. Security */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">7. Security</h2>
+            <p className="text-base leading-relaxed">
+              We use industry-standard security measures to protect your data, including encrypted data transmission
+              (HTTPS), secure authentication via Supabase, and access controls limiting who can access your data.
+              However, no method of transmission over the internet is 100% secure. We encourage you to use a strong,
+              unique password and to sign out when using shared devices.
+            </p>
+          </section>
+
+          {/* 8. Changes */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">8. Changes to This Policy</h2>
+            <p className="text-base leading-relaxed">
+              We may update this Privacy Policy from time to time. We will notify you of significant changes by
+              posting a notice on the platform or by email. Your continued use of My Third Place after any changes
+              indicates your acceptance of the updated policy. The &quot;Effective Date&quot; at the top of this page shows
+              when the policy was last updated.
+            </p>
+          </section>
+
+          {/* 9. Contact */}
+          <section className="border-2 border-foreground bg-accent p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">9. Contact Us</h2>
+            <p className="text-base leading-relaxed">
+              If you have questions or concerns about this Privacy Policy or how we handle your data, please
+              contact us at{" "}
+              <a
+                href="mailto:hello@mythirdplace.in"
+                className="font-bold underline hover:text-primary"
+              >
+                hello@mythirdplace.in
+              </a>
+            </p>
+          </section>
+
+          {/* Footer nav */}
+          <div className="flex gap-4 pt-4">
+            <Link
+              href="/terms"
+              className="text-sm font-bold uppercase tracking-wider underline hover:text-primary"
+            >
+              ← Terms of Service
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -253,10 +253,10 @@ export default function TermsPage() {
             <p className="text-base leading-relaxed">
               If you have questions about these Terms, please contact us at{" "}
               <a
-                href="mailto:hello@mythirdplace.in"
+                href="mailto:hello@rapchai.com"
                 className="font-bold underline hover:text-primary"
               >
-                hello@mythirdplace.in
+                hello@rapchai.com
               </a>
             </p>
           </section>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,277 @@
+import Link from "next/link";
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        {/* Back nav */}
+        <nav className="mb-8">
+          <Link
+            href="/"
+            className="inline-block border-2 border-foreground bg-background px-4 py-2 text-sm font-bold uppercase tracking-wider shadow-brutal hover:shadow-brutal-none hover:translate-x-[4px] hover:translate-y-[4px] transition-all duration-150"
+          >
+            ← Back to Home
+          </Link>
+        </nav>
+
+        {/* Header */}
+        <div className="border-2 border-foreground bg-primary p-6 shadow-brutal-lg mb-8">
+          <h1 className="text-4xl font-extrabold uppercase tracking-wider text-primary-foreground">
+            Terms of Service
+          </h1>
+          <p className="text-primary-foreground/80 mt-2 font-medium">
+            Effective Date: April 1, 2026
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {/* Introduction */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <p className="text-base leading-relaxed">
+              Welcome to My Third Place. By accessing or using our platform, you agree to be bound by these Terms of
+              Service. Please read them carefully. If you do not agree, do not use the platform.
+            </p>
+          </section>
+
+          {/* 1. Acceptance */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">1. Acceptance of Terms</h2>
+            <p className="text-base leading-relaxed">
+              By creating an account or using any part of My Third Place, you confirm that you are at least 18 years
+              old, have read and understood these Terms, and agree to be legally bound by them. These Terms constitute
+              a binding agreement between you and My Third Place.
+            </p>
+          </section>
+
+          {/* 2. Description of Service */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">2. Description of Service</h2>
+            <p className="text-base leading-relaxed mb-3">
+              My Third Place is a community platform that allows users to:
+            </p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Discover and join local community spaces
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Browse, register for, and host community events
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Participate in community discussions
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Connect with people who share local interests
+              </li>
+            </ul>
+            <p className="text-base leading-relaxed mt-3">
+              We reserve the right to modify, suspend, or discontinue any part of the service at any time with
+              reasonable notice.
+            </p>
+          </section>
+
+          {/* 3. User Accounts */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">3. User Accounts</h2>
+            <p className="text-base leading-relaxed mb-3">
+              You are responsible for maintaining the confidentiality of your account credentials and for all
+              activity that occurs under your account. You agree to:
+            </p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Provide accurate and complete registration information
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Keep your password secure and not share it with others
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Notify us immediately of any unauthorized account access
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Not create multiple accounts to circumvent bans or restrictions
+              </li>
+            </ul>
+          </section>
+
+          {/* 4. Community Guidelines */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">4. Community Guidelines</h2>
+            <p className="text-base leading-relaxed mb-3">
+              My Third Place is built on respect and belonging. All users must:
+            </p>
+            <ul className="space-y-2 text-base mb-3">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Treat other members with respect and dignity
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Not post hateful, discriminatory, or harassing content
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Not spam, solicit, or send unsolicited commercial messages
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Not impersonate other users or public figures
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-primary border border-foreground flex-shrink-0" />
+                Not share false or misleading information about events or spaces
+              </li>
+            </ul>
+            <p className="text-base leading-relaxed">
+              Violations may result in content removal, account suspension, or permanent bans at our discretion.
+            </p>
+          </section>
+
+          {/* 5. Content Ownership */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">5. Content Ownership & License</h2>
+            <p className="text-base leading-relaxed mb-3">
+              You retain ownership of any content you submit to the platform, including event descriptions,
+              discussion posts, and profile information. By posting content, you grant My Third Place a
+              non-exclusive, royalty-free, worldwide license to use, display, and distribute that content
+              solely for the purpose of operating and improving the platform.
+            </p>
+            <p className="text-base leading-relaxed">
+              You represent that you have all necessary rights to the content you post and that it does not
+              infringe any third-party rights.
+            </p>
+          </section>
+
+          {/* 6. Event Registration */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">6. Event Registration</h2>
+            <p className="text-base leading-relaxed mb-3">
+              When registering for events on My Third Place:
+            </p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Event details are provided by organizers and we cannot guarantee accuracy
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Refund and cancellation policies are set by individual event organizers
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                We are not responsible for event cancellations or changes made by organizers
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-accent border border-foreground flex-shrink-0" />
+                Any payments are processed through our payment provider and subject to their terms
+              </li>
+            </ul>
+          </section>
+
+          {/* 7. Referral Program */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">7. Referral Program</h2>
+            <p className="text-base leading-relaxed">
+              My Third Place may offer a referral program from time to time. Referral benefits are subject to change
+              and may be revoked if we detect abuse, including generating fraudulent accounts or referrals. We reserve
+              the right to modify or discontinue the referral program at any time. Referral rewards have no cash value
+              unless explicitly stated.
+            </p>
+          </section>
+
+          {/* 8. Prohibited Conduct */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">8. Prohibited Conduct</h2>
+            <p className="text-base leading-relaxed mb-3">You may not:</p>
+            <ul className="space-y-2 text-base">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-destructive border border-foreground flex-shrink-0" />
+                Use the platform for any unlawful purpose
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-destructive border border-foreground flex-shrink-0" />
+                Scrape, crawl, or systematically extract data from the platform
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-destructive border border-foreground flex-shrink-0" />
+                Interfere with the security or integrity of the platform
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-destructive border border-foreground flex-shrink-0" />
+                Attempt to gain unauthorized access to any system or data
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 w-2 h-2 bg-destructive border border-foreground flex-shrink-0" />
+                Transmit viruses, malware, or other harmful code
+              </li>
+            </ul>
+          </section>
+
+          {/* 9. Termination */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">9. Termination</h2>
+            <p className="text-base leading-relaxed">
+              We may suspend or terminate your account at any time, with or without notice, for conduct that we
+              believe violates these Terms or is harmful to other users, us, or third parties. You may delete your
+              account at any time by contacting us. Upon termination, your right to use the platform ceases
+              immediately.
+            </p>
+          </section>
+
+          {/* 10. Disclaimers */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">10. Disclaimers & Limitation of Liability</h2>
+            <p className="text-base leading-relaxed mb-3">
+              The platform is provided &quot;as is&quot; without warranties of any kind. We do not warrant that the platform
+              will be uninterrupted, error-free, or free of harmful components.
+            </p>
+            <p className="text-base leading-relaxed">
+              To the maximum extent permitted by law, My Third Place shall not be liable for any indirect,
+              incidental, special, or consequential damages arising from your use of the platform, including
+              damages resulting from events organised through the platform.
+            </p>
+          </section>
+
+          {/* 11. Governing Law */}
+          <section className="border-2 border-foreground bg-background p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">11. Governing Law</h2>
+            <p className="text-base leading-relaxed">
+              These Terms are governed by the laws of India. Any disputes arising under these Terms shall be
+              subject to the exclusive jurisdiction of the courts located in India.
+            </p>
+          </section>
+
+          {/* 12. Contact */}
+          <section className="border-2 border-foreground bg-accent p-6 shadow-brutal">
+            <h2 className="text-xl font-extrabold uppercase tracking-wider mb-3">12. Contact Us</h2>
+            <p className="text-base leading-relaxed">
+              If you have questions about these Terms, please contact us at{" "}
+              <a
+                href="mailto:hello@mythirdplace.in"
+                className="font-bold underline hover:text-primary"
+              >
+                hello@mythirdplace.in
+              </a>
+            </p>
+          </section>
+
+          {/* Footer nav */}
+          <div className="flex gap-4 pt-4">
+            <Link
+              href="/privacy"
+              className="text-sm font-bold uppercase tracking-wider underline hover:text-primary"
+            >
+              Privacy Policy →
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,6 +32,7 @@ const nextConfig = {
 
   // Turbopack configuration (Next.js 16+ default bundler)
   turbopack: {
+    root: __dirname,
     resolveAlias: {
       '@': path.resolve(__dirname, './src'),
     },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,32 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
+// In-memory rate limiter (per-process only).
+// WARNING: In serverless/multi-instance deployments (e.g. Vercel) each instance
+// maintains its own Map, so the effective limit per user may be multiplied by
+// the number of active instances. For distributed rate limiting, replace this
+// with a shared store such as Upstash Redis + @upstash/ratelimit.
+const _rateLimitStore = new Map<string, { count: number; resetAt: number }>();
+
+const RATE_LIMIT_RULES = [
+  { pattern: /^\/auth\/forgot-password/, maxRequests: 5, windowMs: 60_000 },
+  { pattern: /^\/api\//, maxRequests: 60, windowMs: 60_000 },
+] as const;
+
+function _checkRateLimit(ip: string, patternKey: string, maxRequests: number, windowMs: number): boolean {
+  const key = `${ip}:${patternKey}`;
+  const now = Date.now();
+  const entry = _rateLimitStore.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    _rateLimitStore.set(key, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+  if (entry.count >= maxRequests) return false;
+  entry.count++;
+  return true;
+}
+
 /**
  * Next.js Proxy for Supabase Auth Session Refresh
  * 
@@ -17,6 +43,32 @@ export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   });
+
+  // Prune stale entries if store grows large (prevents unbounded memory growth)
+  if (_rateLimitStore.size > 10_000) {
+    const now = Date.now();
+    for (const [key, val] of _rateLimitStore) {
+      if (now > val.resetAt) _rateLimitStore.delete(key);
+    }
+  }
+
+  const pathname = request.nextUrl.pathname;
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+
+  for (const rule of RATE_LIMIT_RULES) {
+    if (rule.pattern.test(pathname)) {
+      if (!_checkRateLimit(ip, rule.pattern.source, rule.maxRequests, rule.windowMs)) {
+        return new NextResponse('Too Many Requests', {
+          status: 429,
+          headers: { 'Retry-After': '60', 'Content-Type': 'text/plain' },
+        });
+      }
+      break;
+    }
+  }
 
   // Support both naming conventions for the anon key
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -77,9 +129,9 @@ export async function proxy(request: NextRequest) {
     if (error) {
       console.warn('[Proxy] Supabase getUser() returned an error. Skipping session refresh.', {
         pathname: request.nextUrl?.pathname,
-        status: (error as any)?.status,
-        code: (error as any)?.code,
-        message: (error as any)?.message,
+        status: (error as { status?: number })?.status,
+        code: (error as { code?: string })?.code,
+        message: (error as { message?: string })?.message,
       });
     }
   } catch (error) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 const _rateLimitStore = new Map<string, { count: number; resetAt: number }>();
 
 const RATE_LIMIT_RULES = [
-  { pattern: /^\/auth\/forgot-password/, maxRequests: 5, windowMs: 60_000 },
+  // Rate-limit the server action that sends the email, not the page view
+  { pattern: /^\/api\/auth\/reset-password/, maxRequests: 5, windowMs: 60_000 },
   { pattern: /^\/api\//, maxRequests: 60, windowMs: 60_000 },
 ] as const;
 
@@ -56,11 +57,13 @@ export async function proxy(request: NextRequest) {
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
     request.headers.get('x-real-ip') ||
-    'unknown';
+    null;
 
+  // Skip rate limiting when IP cannot be determined — a shared fallback key
+  // would let one client exhaust the quota for all unidentified clients.
   for (const rule of RATE_LIMIT_RULES) {
     if (rule.pattern.test(pathname)) {
-      if (!_checkRateLimit(ip, rule.pattern.source, rule.maxRequests, rule.windowMs)) {
+      if (ip && !_checkRateLimit(ip, rule.pattern.source, rule.maxRequests, rule.windowMs)) {
         return new NextResponse('Too Many Requests', {
           status: 429,
           headers: { 'Retry-After': '60', 'Content-Type': 'text/plain' },

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useLocation, Link } from "@/lib/nextRouterAdapter";
+import { Footer } from "./Footer";
 import { Users, Calendar, MessageSquare, User, Sun, Moon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
@@ -151,6 +152,8 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
           {children}
         </div>
       </main>
+
+      <Footer />
 
       {/* Mobile Bottom Navigation - Neo-Brutal */}
       {user && (

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Link } from "@/lib/nextRouterAdapter";
+
+export const Footer = () => {
+  return (
+    <footer className="border-t-2 border-foreground bg-background mb-20 md:mb-0">
+      <div className="max-w-7xl mx-auto px-4 md:px-6 py-8">
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
+          {/* Brand */}
+          <div>
+            <p className="font-extrabold uppercase tracking-wider text-base">My Third Place</p>
+            <p className="text-xs text-muted-foreground mt-1 font-medium">Your community, your space.</p>
+          </div>
+
+          {/* Legal links */}
+          <div className="flex gap-6">
+            <Link
+              to="/terms"
+              className="text-xs font-bold uppercase tracking-wider text-muted-foreground hover:text-primary transition-colors"
+            >
+              Terms of Service
+            </Link>
+            <Link
+              to="/privacy"
+              className="text-xs font-bold uppercase tracking-wider text-muted-foreground hover:text-primary transition-colors"
+            >
+              Privacy Policy
+            </Link>
+          </div>
+        </div>
+
+        <div className="border-t border-foreground/20 mt-6 pt-4">
+          <p className="text-xs text-muted-foreground font-medium">
+            © {new Date().getFullYear()} My Third Place. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,6 +11,8 @@ interface AuthContextType {
   signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signInWithGoogle: () => Promise<{ error: AuthError | null }>;
   signOut: () => Promise<{ error: AuthError | null }>;
+  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
+  updatePassword: (newPassword: string) => Promise<{ error: AuthError | null }>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -100,6 +102,18 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return { error };
   };
 
+  const resetPassword = async (email: string) => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/reset-password`,
+    });
+    return { error };
+  };
+
+  const updatePassword = async (newPassword: string) => {
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    return { error };
+  };
+
   const value = {
     user,
     session,
@@ -108,6 +122,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     signIn,
     signInWithGoogle,
     signOut,
+    resetPassword,
+    updatePassword,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/views/Auth.tsx
+++ b/src/views/Auth.tsx
@@ -242,6 +242,12 @@ export const AuthPage = () => {
                       />
                     </div>
 
+                    <div className="flex justify-end">
+                      <Link to="/auth/forgot-password" className="text-xs font-bold uppercase tracking-wider text-muted-foreground hover:text-primary">
+                        Forgot password?
+                      </Link>
+                    </div>
+
                     {error && (
                       <Alert variant="destructive">
                         <AlertDescription>{error}</AlertDescription>
@@ -363,6 +369,19 @@ export const AuthPage = () => {
             )}
           </CardContent>
         </Card>
+
+        {currentTab === "signup" && (
+          <p className="text-center text-xs text-muted-foreground mt-4">
+            By creating an account, you agree to our{" "}
+            <Link to="/terms" className="font-bold underline hover:text-primary">
+              Terms of Service
+            </Link>
+            {" "}and{" "}
+            <Link to="/privacy" className="font-bold underline hover:text-primary">
+              Privacy Policy
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/views/Auth.tsx
+++ b/src/views/Auth.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, useLocation, useSearchParams } from "@/lib/nextRouterAdapter";
+import { useNavigate, useLocation, useSearchParams, Link } from "@/lib/nextRouterAdapter";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/src/views/ForgotPassword.tsx
+++ b/src/views/ForgotPassword.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { Link } from "@/lib/nextRouterAdapter";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useAuth } from "@/contexts/AuthContext";
+
+type State = "idle" | "loading" | "success";
+
+export const ForgotPassword = () => {
+  const [email, setEmail] = useState("");
+  const [state, setState] = useState<State>("idle");
+  const [error, setError] = useState("");
+
+  const { resetPassword } = useAuth();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setState("loading");
+    setError("");
+
+    const { error } = await resetPassword(email);
+
+    if (error) {
+      setError(error.message);
+      setState("idle");
+    } else {
+      setState("success");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md">
+        {/* Logo */}
+        <div className="flex justify-center mb-8">
+          <a
+            href="/"
+            className="inline-block border-2 border-foreground bg-background px-4 py-2 shadow-brutal hover:shadow-brutal-none hover:translate-x-[4px] hover:translate-y-[4px] transition-all duration-150"
+          >
+            <img src="/logo.png" alt="My Third Place" className="h-16 w-auto" loading="eager" decoding="async" />
+          </a>
+        </div>
+
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl font-bold text-primary">Reset your password</CardTitle>
+            <CardDescription>
+              Enter your email and we&apos;ll send you a reset link.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {state === "success" ? (
+              <div className="space-y-4">
+                <div className="border-2 border-foreground bg-accent p-4 shadow-brutal">
+                  <p className="font-bold uppercase tracking-wider text-sm mb-1">Check your email</p>
+                  <p className="text-sm text-muted-foreground">
+                    If an account exists for <strong>{email}</strong>, we&apos;ve sent a password reset link.
+                    The link expires in 1 hour.
+                  </p>
+                </div>
+                <p className="text-center text-xs text-muted-foreground">
+                  Didn&apos;t receive it? Check your spam folder or{" "}
+                  <button
+                    onClick={() => { setState("idle"); setEmail(""); }}
+                    className="font-bold underline hover:text-primary"
+                  >
+                    try again
+                  </button>
+                </p>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="reset-email">Email address</Label>
+                  <Input
+                    id="reset-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    disabled={state === "loading"}
+                    placeholder="you@example.com"
+                  />
+                </div>
+
+                {error && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+
+                <Button type="submit" className="w-full" disabled={state === "loading"}>
+                  {state === "loading" ? "Sending..." : "Send Reset Link"}
+                </Button>
+              </form>
+            )}
+
+            <div className="mt-6 text-center">
+              <Link
+                to="/auth"
+                className="text-xs font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+              >
+                ← Back to Sign In
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/views/ForgotPassword.tsx
+++ b/src/views/ForgotPassword.tsx
@@ -5,8 +5,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { useAuth } from "@/contexts/AuthContext";
-
 type State = "idle" | "loading" | "success";
 
 export const ForgotPassword = () => {
@@ -14,21 +12,37 @@ export const ForgotPassword = () => {
   const [state, setState] = useState<State>("idle");
   const [error, setError] = useState("");
 
-  const { resetPassword } = useAuth();
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setState("loading");
     setError("");
 
-    const { error } = await resetPassword(email);
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
 
-    if (error) {
-      setError(error.message);
+      if (res.status === 429) {
+        setError("Too many requests. Please wait a minute before trying again.");
+        setState("idle");
+        return;
+      }
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? "Something went wrong. Please try again.");
+        setState("idle");
+        return;
+      }
+    } catch {
+      setError("Network error. Please check your connection and try again.");
       setState("idle");
-    } else {
-      setState("success");
+      return;
     }
+
+    setState("success");
   };
 
   return (

--- a/src/views/ResetPassword.tsx
+++ b/src/views/ResetPassword.tsx
@@ -1,0 +1,186 @@
+import { useState, useEffect } from "react";
+import { Link, useNavigate } from "@/lib/nextRouterAdapter";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+
+type State = "detecting" | "ready" | "loading" | "success" | "error";
+
+export const ResetPassword = () => {
+  const [state, setState] = useState<State>("detecting");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const { updatePassword } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Wait for Supabase to fire PASSWORD_RECOVERY from the reset link
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "PASSWORD_RECOVERY") {
+        setState("ready");
+      }
+    });
+
+    // Timeout: if no PASSWORD_RECOVERY fires within 8s, the link is invalid/expired
+    const timeout = setTimeout(() => {
+      setState((current) => {
+        if (current === "detecting") return "error";
+        return current;
+      });
+    }, 8000);
+
+    return () => {
+      subscription.unsubscribe();
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password !== confirmPassword) {
+      setError("Passwords don't match");
+      return;
+    }
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters");
+      return;
+    }
+
+    setState("loading");
+
+    const { error } = await updatePassword(password);
+
+    if (error) {
+      setError(error.message);
+      setState("ready");
+    } else {
+      setState("success");
+      toast({
+        title: "Password updated!",
+        description: "You can now sign in with your new password.",
+      });
+      setTimeout(() => navigate("/auth"), 1500);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md">
+        {/* Logo */}
+        <div className="flex justify-center mb-8">
+          <a
+            href="/"
+            className="inline-block border-2 border-foreground bg-background px-4 py-2 shadow-brutal hover:shadow-brutal-none hover:translate-x-[4px] hover:translate-y-[4px] transition-all duration-150"
+          >
+            <img src="/logo.png" alt="My Third Place" className="h-16 w-auto" loading="eager" decoding="async" />
+          </a>
+        </div>
+
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl font-bold text-primary">Set new password</CardTitle>
+            <CardDescription>
+              {state === "detecting" ? "Verifying your reset link…" : "Choose a new password for your account."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {state === "detecting" && (
+              <div className="space-y-4">
+                <div className="flex items-center justify-center py-6">
+                  <div className="w-8 h-8 border-2 border-foreground border-t-primary animate-spin" />
+                </div>
+                <p className="text-center text-sm text-muted-foreground">
+                  Verifying your reset link…
+                </p>
+              </div>
+            )}
+
+            {state === "error" && (
+              <div className="space-y-4">
+                <div className="border-2 border-destructive bg-destructive/10 p-4">
+                  <p className="font-bold uppercase tracking-wider text-sm text-destructive mb-1">Link expired or invalid</p>
+                  <p className="text-sm text-muted-foreground">
+                    This password reset link has expired or is invalid. Please request a new one.
+                  </p>
+                </div>
+                <Button asChild className="w-full">
+                  <Link to="/auth/forgot-password">Request New Reset Link</Link>
+                </Button>
+              </div>
+            )}
+
+            {state === "success" && (
+              <div className="border-2 border-foreground bg-accent p-4 shadow-brutal">
+                <p className="font-bold uppercase tracking-wider text-sm mb-1">Password updated!</p>
+                <p className="text-sm text-muted-foreground">
+                  Redirecting you to sign in…
+                </p>
+              </div>
+            )}
+
+            {(state === "ready" || state === "loading") && (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="new-password">New password</Label>
+                  <Input
+                    id="new-password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    disabled={state === "loading"}
+                    minLength={6}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="confirm-new-password">Confirm new password</Label>
+                  <Input
+                    id="confirm-new-password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    disabled={state === "loading"}
+                    minLength={6}
+                  />
+                </div>
+
+                {error && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+
+                <Button type="submit" className="w-full" disabled={state === "loading"}>
+                  {state === "loading" ? "Updating…" : "Update Password"}
+                </Button>
+              </form>
+            )}
+
+            {state !== "error" && state !== "success" && (
+              <div className="mt-6 text-center">
+                <Link
+                  to="/auth"
+                  className="text-xs font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+                >
+                  ← Back to Sign In
+                </Link>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
- Add Terms of Service (/terms) and Privacy Policy (/privacy) pages with neo-brutalism styling
- Add Footer component with Terms/Privacy links, wired into AppLayout
- Add forgot password link to sign-in tab and Terms/Privacy consent notice on sign-up tab
- Add resetPassword and updatePassword methods to AuthContext
- Add /auth/forgot-password page (email input, prevents user enumeration)
- Add /auth/reset-password page (handles PASSWORD_RECOVERY event, 8s timeout for expired links)
- Add in-memory rate limiting in proxy.ts (5 req/min on forgot-password, 60 req/min on /api/*)
- Set turbopack.root in next.config.mjs to silence workspace root warning